### PR TITLE
fix: ChatApp 컴포넌트 구현 및 세션 전환 race condition 수정

### DIFF
--- a/components/chat/ChatApp.tsx
+++ b/components/chat/ChatApp.tsx
@@ -26,6 +26,8 @@ export function ChatApp({ initialSessions, initialSessionId, initialMessages }: 
   const [activeId, setActiveId] = useState<string>(initialSessionId)
   const [input, setInput] = useState('')
   const [isSwitching, setIsSwitching] = useState(false)
+  // 세션 전환 중 race condition 방지: 가장 최근 요청 ID만 반영
+  const pendingSessionRef = useRef<string | null>(null)
 
   const { messages, sendMessage, setMessages, status } = useChat({
     id: activeId,
@@ -42,11 +44,13 @@ export function ChatApp({ initialSessions, initialSessionId, initialMessages }: 
     prevStatusRef.current = status
   }, [status, messages.length])
 
-  // 세션 전환
+  // 세션 전환 — race condition 방지: fetch 완료 시점에 다른 세션이 선택됐으면 무시
   const handleSelectSession = useCallback(async (id: string) => {
+    pendingSessionRef.current = id
     setActiveId(id)
     setIsSwitching(true)
     const dbMessages = await getMessages(id)
+    if (pendingSessionRef.current !== id) return
     const uiMessages: UIMessage[] = dbMessages.map((m) => ({
       id: m.id,
       role: m.role as 'user' | 'assistant',


### PR DESCRIPTION
## Summary

- `components/chat/ChatApp.tsx` 구현 — `ChatSidebar` + `ChatWindow` + `ChatInput`을 조합하는 `"use client"` 최상위 컴포넌트
- 세션 전환 중 race condition 수정: 빠르게 세션을 전환할 때 이전 `getMessages()` fetch 결과가 현재 세션 메시지를 덮어쓰는 버그를 `pendingSessionRef`로 방지

## Changes

**`components/chat/ChatApp.tsx`**
- `pendingSessionRef` 추가 — 세션 전환 요청 ID 추적
- `handleSelectSession`에서 fetch 완료 시 최신 요청과 다르면 상태 업데이트 스킵

## Test plan

- [ ] 앱 빌드 성공 확인 (`npm run build`)
- [ ] 새 채팅 생성 후 메시지 전송 정상 동작
- [ ] 세션 목록에서 다른 세션 클릭 시 해당 메시지 로드
- [ ] 세션을 빠르게 연속 클릭해도 마지막 선택 세션 메시지가 올바르게 표시

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)