### PR TITLE
feat: 멀티모달 이미지 첨부 지원

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,37 +6,52 @@ import { updateSessionTitle } from '@/lib/db/sessions'
 export const maxDuration = 60
 
 export async function POST(req: Request) {
-  const { messages, sessionId }: { messages: UIMessage[]; sessionId: string } =
-    await req.json()
+  try {
+    const { messages, sessionId }: { messages: UIMessage[]; sessionId: string } =
+      await req.json()
 
-  const result = streamText({
-    model: anthropic('claude-sonnet-4-6'),
-    system: '당신은 친절하고 유능한 AI 어시스턴트입니다. 한국어로 질문하면 한국어로 답하세요.',
-    messages: await convertToModelMessages(messages),
-    onFinish: async ({ text }) => {
-      const allMessages = [
-        ...messages.map((m) => ({
-          role: m.role,
-          content: m.parts
-            .filter((p) => p.type === 'text')
-            .map((p) => (p as { type: 'text'; text: string }).text)
-            .join(''),
-        })),
-        { role: 'assistant', content: text },
-      ]
-      await saveMessages(sessionId, allMessages)
+    const result = streamText({
+      model: anthropic('claude-sonnet-4-6'),
+      system: '당신은 친절하고 유능한 AI 어시스턴트입니다. 한국어로 질문하면 한국어로 답하세요.',
+      messages: await convertToModelMessages(messages),
+      onFinish: async ({ text }) => {
+        try {
+          const extractText = (m: UIMessage) =>
+            m.parts
+              .filter((p) => p.type === 'text')
+              .map((p) => (p as { type: 'text'; text: string }).text)
+              .join('')
 
-      // 첫 번째 사용자 메시지로 세션 제목 설정
-      if (messages.length === 1) {
-        const firstUserMsg = messages[0].parts
-          .filter((p) => p.type === 'text')
-          .map((p) => (p as { type: 'text'; text: string }).text)
-          .join('')
-        const title = firstUserMsg.slice(0, 30) + (firstUserMsg.length > 30 ? '...' : '')
-        await updateSessionTitle(sessionId, title)
-      }
-    },
-  })
+          const hasImage = (m: UIMessage) => m.parts.some((p) => p.type === 'file')
 
-  return result.toUIMessageStreamResponse()
+          const allMessages = [
+            ...messages.map((m) => ({
+              role: m.role,
+              // 이미지 첨부 메시지는 텍스트 앞에 [이미지] 표시
+              content: `${hasImage(m) ? '[이미지] ' : ''}${extractText(m)}`,
+            })),
+            { role: 'assistant', content: text },
+          ]
+          await saveMessages(sessionId, allMessages)
+
+          if (messages.length === 1) {
+            const firstText = extractText(messages[0])
+            const base = firstText || (hasImage(messages[0]) ? '이미지 첨부' : '새 채팅')
+            const title = base.slice(0, 30) + (base.length > 30 ? '...' : '')
+            await updateSessionTitle(sessionId, title)
+          }
+        } catch (dbError) {
+          console.error('[onFinish] DB 저장 실패:', dbError)
+        }
+      },
+    })
+
+    return result.toUIMessageStreamResponse()
+  } catch (error) {
+    console.error('[POST /api/chat] 오류:', error)
+    return new Response(JSON.stringify({ error: String(error) }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
 }

--- a/components/chat/ChatApp.tsx
+++ b/components/chat/ChatApp.tsx
@@ -5,7 +5,7 @@ import { useChat, UIMessage } from '@ai-sdk/react'
 import { DefaultChatTransport } from 'ai'
 import { ChatSidebar } from './ChatSidebar'
 import { ChatWindow } from './ChatWindow'
-import { ChatInput } from './ChatInput'
+import { ChatInput, type AttachedImage } from './ChatInput'
 import { createSession, getSessions } from '@/lib/db/sessions'
 import { getMessages } from '@/lib/db/messages'
 
@@ -26,6 +26,7 @@ export function ChatApp({ initialSessions, initialSessionId, initialMessages }: 
   const [activeId, setActiveId] = useState<string>(initialSessionId)
   const [input, setInput] = useState('')
   const [isSwitching, setIsSwitching] = useState(false)
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([])
   // 세션 전환 중 race condition 방지: 가장 최근 요청 ID만 반영
   const pendingSessionRef = useRef<string | null>(null)
 
@@ -85,13 +86,29 @@ export function ChatApp({ initialSessions, initialSessionId, initialMessages }: 
     }
   }, [activeId, handleSelectSession, setMessages])
 
-  // 메시지 전송 — sessionId를 body에 포함
+  // 메시지 전송 — 이미지 첨부 시 file 파트 포함
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault()
-    if (!input.trim() || status === 'streaming' || status === 'submitted') return
-    sendMessage({ text: input }, { body: { sessionId: activeId } })
+    const hasContent = input.trim().length > 0 || attachedImages.length > 0
+    if (!hasContent || status === 'streaming' || status === 'submitted') return
+
+    if (attachedImages.length > 0) {
+      const parts: { type: 'file'; mediaType: string; url: string }[] = attachedImages.map((img) => ({
+        type: 'file' as const,
+        mediaType: img.mediaType,
+        url: img.dataUrl,
+      }))
+      sendMessage(
+        { parts: input.trim() ? [...parts, { type: 'text' as const, text: input }] : parts },
+        { body: { sessionId: activeId } }
+      )
+    } else {
+      sendMessage({ text: input }, { body: { sessionId: activeId } })
+    }
+
     setInput('')
-  }, [input, status, sendMessage, activeId])
+    setAttachedImages([])
+  }, [input, attachedImages, status, sendMessage, activeId])
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -109,6 +126,8 @@ export function ChatApp({ initialSessions, initialSessionId, initialMessages }: 
           onInputChange={setInput}
           onSubmit={handleSubmit}
           status={status}
+          attachedImages={attachedImages}
+          onImagesChange={setAttachedImages}
         />
       </main>
     </div>

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -3,23 +3,51 @@
 import { useRef } from 'react'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
-import { SendHorizonal } from 'lucide-react'
+import { SendHorizonal, Paperclip, X } from 'lucide-react'
+
+export interface AttachedImage {
+  dataUrl: string
+  mediaType: string
+  name: string
+}
 
 interface Props {
   input: string
   onInputChange: (value: string) => void
   onSubmit: (e: React.FormEvent) => void
   status: 'submitted' | 'streaming' | 'ready' | 'error'
+  attachedImages: AttachedImage[]
+  onImagesChange: (images: AttachedImage[]) => void
 }
 
-export function ChatInput({ input, onInputChange, onSubmit, status }: Props) {
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}
+
+export function ChatInput({
+  input,
+  onInputChange,
+  onSubmit,
+  status,
+  attachedImages,
+  onImagesChange,
+}: Props) {
   const isLoading = status === 'streaming' || status === 'submitted'
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      if (input.trim() && !isLoading) {
+      if ((input.trim() || attachedImages.length > 0) && !isLoading) {
         onSubmit(e as unknown as React.FormEvent)
       }
     }
@@ -32,26 +60,124 @@ export function ChatInput({ input, onInputChange, onSubmit, status }: Props) {
     el.style.height = el.scrollHeight + 'px'
   }
 
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    e.target.value = ''
+
+    const newImages: AttachedImage[] = []
+    for (const file of files) {
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        alert(`지원하지 않는 형식입니다: ${file.name}`)
+        continue
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        alert(`파일 크기가 5MB를 초과합니다: ${file.name}`)
+        continue
+      }
+      const dataUrl = await readFileAsDataUrl(file)
+      newImages.push({ dataUrl, mediaType: file.type, name: file.name })
+    }
+    if (newImages.length > 0) {
+      onImagesChange([...attachedImages, ...newImages])
+    }
+  }
+
+  const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    const files = Array.from(e.dataTransfer.files).filter((f) =>
+      ACCEPTED_TYPES.includes(f.type)
+    )
+    if (files.length === 0) return
+    const newImages: AttachedImage[] = []
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        alert(`파일 크기가 5MB를 초과합니다: ${file.name}`)
+        continue
+      }
+      const dataUrl = await readFileAsDataUrl(file)
+      newImages.push({ dataUrl, mediaType: file.type, name: file.name })
+    }
+    if (newImages.length > 0) {
+      onImagesChange([...attachedImages, ...newImages])
+    }
+  }
+
+  const removeImage = (index: number) => {
+    onImagesChange(attachedImages.filter((_, i) => i !== index))
+  }
+
+  const canSubmit = (input.trim().length > 0 || attachedImages.length > 0) && !isLoading
+
   return (
-    <form onSubmit={onSubmit} className="flex items-end gap-2 p-4 border-t">
-      <Textarea
-        ref={textareaRef}
-        value={input}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder="메시지를 입력하세요... (Enter: 전송, Shift+Enter: 줄바꿈)"
-        rows={1}
-        className="resize-none min-h-[44px] max-h-[200px]"
-        disabled={isLoading}
-      />
-      <Button
-        type="submit"
-        size="icon"
-        disabled={!input.trim() || isLoading}
-        className="shrink-0"
-      >
-        <SendHorizonal className="h-4 w-4" />
-      </Button>
-    </form>
+    <div
+      className="border-t"
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+    >
+      {/* 이미지 미리보기 */}
+      {attachedImages.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-4 pt-3">
+          {attachedImages.map((img, i) => (
+            <div key={i} className="relative">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={img.dataUrl}
+                alt={img.name}
+                className="h-16 w-16 rounded-lg object-cover border"
+              />
+              <button
+                type="button"
+                onClick={() => removeImage(i)}
+                className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+              >
+                <X className="h-2.5 w-2.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <form onSubmit={onSubmit} className="flex items-end gap-2 p-4">
+        {/* 숨겨진 파일 입력 */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES.join(',')}
+          multiple
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        {/* 첨부 버튼 */}
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          disabled={isLoading}
+          className="shrink-0"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip className="h-4 w-4" />
+        </Button>
+
+        <Textarea
+          ref={textareaRef}
+          value={input}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder="메시지를 입력하세요... (Enter: 전송, Shift+Enter: 줄바꿈)"
+          rows={1}
+          className="resize-none min-h-[44px] max-h-[200px]"
+          disabled={isLoading}
+        />
+        <Button
+          type="submit"
+          size="icon"
+          disabled={!canSubmit}
+          className="shrink-0"
+        >
+          <SendHorizonal className="h-4 w-4" />
+        </Button>
+      </form>
+    </div>
   )
 }

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -17,6 +17,12 @@ export function ChatMessage({ message }: Props) {
     .map((p) => (p as { type: 'text'; text: string }).text)
     .join('')
 
+  const fileParts = message.parts.filter((p) => p.type === 'file') as {
+    type: 'file'
+    mediaType: string
+    url: string
+  }[]
+
   return (
     <div className={cn('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
       <div
@@ -27,8 +33,22 @@ export function ChatMessage({ message }: Props) {
             : 'bg-muted text-foreground'
         )}
       >
+        {/* 첨부 이미지 렌더링 */}
+        {fileParts.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {fileParts.map((part, i) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={i}
+                src={part.url}
+                alt="첨부 이미지"
+                className="max-h-60 max-w-full rounded-lg object-contain"
+              />
+            ))}
+          </div>
+        )}
         {isUser ? (
-          <p className="whitespace-pre-wrap">{text}</p>
+          text ? <p className="whitespace-pre-wrap">{text}</p> : null
         ) : (
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}


### PR DESCRIPTION
## Summary

- `ChatInput`에 이미지 첨부 버튼(📎) 추가 — 클릭 또는 드래그앤드롭으로 업로드
- PNG / JPEG / GIF / WebP 지원, 5MB 초과 시 알림
- 전송 전 썸네일 미리보기 + 개별 제거(×) 버튼
- `ChatMessage`에서 첨부 이미지 렌더링
- `sendMessage`에 `{ type: 'file', mediaType, url }` 파트 포함 → AI SDK `convertToModelMessages`가 Claude Vision으로 자동 전달
- 이미지만 전송 시에도 동작 (텍스트 없이 이미지만 첨부 가능)
- DB 저장: 텍스트 파트만 추출, 이미지 포함 메시지에 `[이미지]` 접두어 표기

## Test plan

- [ ] 📎 버튼 클릭 → 파일 선택 다이얼로그 열림
- [ ] 이미지 드래그앤드롭 가능
- [ ] 썸네일 미리보기 표시, × 버튼으로 제거
- [ ] 이미지 + 텍스트 함께 전송 → Claude가 이미지 내용 인식한 응답 반환
- [ ] 이미지만 전송 (텍스트 없이) 동작
- [ ] 5MB 초과 파일 알림 메시지 표시
- [ ] 지원하지 않는 형식(PDF 등) 알림 메시지 표시

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)