### PR TITLE
fix: 버그 4건 및 CI/설정 오류 수정 (#2 #3 #5 #6)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,10 @@ name: Deploy to Vercel
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install Vercel CLI

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -24,19 +24,19 @@ export async function POST(req: Request) {
 
           const hasImage = (m: UIMessage) => m.parts.some((p) => p.type === 'file')
 
-          const allMessages = [
-            ...messages.map((m) => ({
-              role: m.role,
-              // 이미지 첨부 메시지는 텍스트 앞에 [이미지] 표시
-              content: `${hasImage(m) ? '[이미지] ' : ''}${extractText(m)}`,
-            })),
+          // 신규 메시지 2개(user + assistant)만 append — 전체 재삽입 방지
+          const lastUserMsg = messages[messages.length - 1]
+          await saveMessages(sessionId, [
+            {
+              role: lastUserMsg.role,
+              content: `${hasImage(lastUserMsg) ? '[이미지] ' : ''}${extractText(lastUserMsg)}`,
+            },
             { role: 'assistant', content: text },
-          ]
-          await saveMessages(sessionId, allMessages)
+          ])
 
           if (messages.length === 1) {
-            const firstText = extractText(messages[0])
-            const base = firstText || (hasImage(messages[0]) ? '이미지 첨부' : '새 채팅')
+            const firstText = extractText(lastUserMsg)
+            const base = firstText || (hasImage(lastUserMsg) ? '이미지 첨부' : '새 채팅')
             const title = base.slice(0, 30) + (base.length > 30 ? '...' : '')
             await updateSessionTitle(sessionId, title)
           }

--- a/lib/db/messages.ts
+++ b/lib/db/messages.ts
@@ -14,7 +14,6 @@ export async function saveMessages(
   messages: { role: string; content: string }[]
 ) {
   await prisma.$transaction([
-    prisma.message.deleteMany({ where: { sessionId } }),
     prisma.message.createMany({
       data: messages.map((m) => ({ ...m, sessionId })),
     }),

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  output: 'standalone',
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,7 @@ model ChatSession {
 model Message {
   id        String      @id @default(cuid())
   role      String
-  content   String
+  content   String  @db.Text
   createdAt DateTime    @default(now())
   sessionId String
   session   ChatSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

| 이슈 | 내용 | 수정 |
|------|------|------|
| #2 | saveMessages 전체 삭제→재삽입 (데이터 손실 위험) | append only로 변경, route.ts에서 신규 메시지 2개만 전달 |
| #3 | Message.content @db.Text 누락 | schema.prisma에 `@db.Text` 추가 |
| #5 | output: 'standalone' Vercel 충돌 | next.config.ts에서 제거 |
| #6 | CI Node.js 20 / 브랜치 main | Node.js 24로 업그레이드, main→master 수정 |

## 주요 변경 상세

**#2 saveMessages 로직 변경**
- 기존: 매 응답마다 해당 세션 전체 메시지 삭제 후 전부 재삽입 → DB 트랜잭션 실패 시 전체 대화 삭제 위험
- 변경: `createMany`로 신규 메시지(user + assistant)만 append
- route.ts: `messages` 전체 대신 `messages[messages.length - 1]` + `text` 만 저장

## Test plan

- [ ] 채팅 전송 시 메시지가 DB에 정상 저장되는지 확인
- [ ] 여러 번 대화 후 새로고침해도 전체 히스토리 유지되는지 확인
- [ ] Vercel 배포 정상 동작 (standalone 제거 후)
- [ ] GitHub Actions deploy.yml이 master 브랜치 push에 트리거되는지 확인

Closes #2, #3, #5, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)